### PR TITLE
fix(create_column_definition): add a third param for options to match the rails abstract definition

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(name, type)
-          Redshift::ColumnDefinition.new name, type
+        def create_column_definition(name, type, options)
+          Redshift::ColumnDefinition.new(name, type, options)
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -55,7 +55,7 @@ module ActiveRecord
         private
 
         def create_column_definition(name, type, options)
-          Redshift::ColumnDefinition.new(name, type, options)
+          Redshift::ColumnDefinition.new(name, type)
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -54,8 +54,8 @@ module ActiveRecord
 
         private
 
-        def create_column_definition(name, type, options)
-          Redshift::ColumnDefinition.new(name, type)
+        def create_column_definition(*args)
+          Redshift::ColumnDefinition.new(*args)
         end
       end
 


### PR DESCRIPTION
Noticed an error with a task that is trying to create Redshift schema. Sure enough, the [abstract definition](https://github.com/rails/rails/blame/master/activerecord/lib/active_record/connection_adapters/abstract/schema_definitions.rb#L430) for `new_column_definition` calls `create_column_definition` with a third `options` param.

```
ArgumentError: wrong number of arguments (given 3, expected 2)
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/bundler/gems/activerecord6-redshift-adapter-95c2c18c816d/lib/active_record/connection_adapters/redshift/schema_definitions.rb:57:in `create_column_definition'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:436:in `new_column_definition'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:378:in `column'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:229:in `block in string'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:229:in `each'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_definitions.rb:229:in `string'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/schema_migration.rb:34:in `block in create_table'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/connection_adapters/abstract/schema_statements.rb:309:in `create_table'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/schema_migration.rb:33:in `create_table'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/migration.rb:1206:in `initialize'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/migration.rb:1061:in `new'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/migration.rb:1061:in `up'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/migration.rb:1036:in `migrate'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/tasks/database_tasks.rb:238:in `migrate'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/railties/databases.rake:85:in `block (3 levels) in <top (required)>'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/railties/databases.rake:83:in `each'
/Users/theblang/.rvm/gems/ruby-2.6.5@back_royal/gems/activerecord-6.0.1/lib/active_record/railties/databases.rake:83:in `block (2 levels) in <top (required)>'
/Users/theblang/pedago/back_royal/Rakefile:32:in `execute'
/Users/theblang/pedago/back_royal/lib/tasks/db_redshift.rake:77:in `block (3 levels) in <top (required)>'
/Users/theblang/pedago/back_royal/Rakefile:32:in `execute'
```