### PR TITLE
Schema Statements: schema_names should use select_values

### DIFF
--- a/activerecord6-redshift-adapter.gemspec
+++ b/activerecord6-redshift-adapter.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
   s.add_runtime_dependency 'pg', '>= 0.18'
-  s.add_runtime_dependency 'activerecord', '~> 6', '>= 6.0.0'
+  s.add_runtime_dependency 'activerecord', '~> 6.0', '>= 6.0.0'
 end

--- a/activerecord6-redshift-adapter.gemspec
+++ b/activerecord6-redshift-adapter.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
   s.add_runtime_dependency 'pg', '>= 0.18'
-  s.add_runtime_dependency 'activerecord', '~> 6.0', '>= 6.0.0'
+  s.add_runtime_dependency 'activerecord', '~> 6', '>= 6.0.0'
 end

--- a/activerecord6-redshift-adapter.gemspec
+++ b/activerecord6-redshift-adapter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'activerecord6-redshift-adapter'
-  s.version = '1.1.3'
+  s.version = '1.1.4'
   s.summary = 'Amazon Redshift adapter for ActiveRecord '
   s.description = 'Amazon Redshift _makeshift_ adapter for ActiveRecord 6.'
   s.license = 'MIT'
@@ -15,5 +15,5 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.2.2'
   s.add_runtime_dependency 'pg', '>= 0.18'
-  s.add_runtime_dependency 'activerecord', '~> 6.0', '>= 6.0.0'
+  s.add_runtime_dependency 'activerecord', '< 7', '>= 6.1'
 end

--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class RedshiftColumn < Column #:nodoc:
       delegate :oid, :fmod, to: :sql_type_metadata
 
-      def initialize(name, default, sql_type_metadata, null = true, default_function = nil)
+      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil)
         super name, default, sql_type_metadata, null, default_function
       end
     end

--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -3,6 +3,11 @@ module ActiveRecord
     class RedshiftColumn < Column #:nodoc:
       delegate :oid, :fmod, to: :sql_type_metadata
 
+      def array
+        false
+      end
+      alias :array? :array
+
     end
   end
 end

--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -3,9 +3,6 @@ module ActiveRecord
     class RedshiftColumn < Column #:nodoc:
       delegate :oid, :fmod, to: :sql_type_metadata
 
-      def initialize(name, default, sql_type_metadata = nil, null = true, default_function = nil)
-        super name, default, sql_type_metadata, null, default_function
-      end
     end
   end
 end

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -154,7 +154,7 @@ module ActiveRecord
             default_value = extract_value_from_default(default)
             type_metadata = fetch_type_metadata(column_name, type, oid, fmod)
             default_function = extract_default_function(default_value, default)
-            new_column(column_name, default_value, type_metadata, notnull == 'f', table_name, default_function)
+            new_column(column_name, default_value, type_metadata, !notnull, table_name, default_function)
           end
         end
 

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -185,7 +185,7 @@ module ActiveRecord
 
         # Returns an array of schema names.
         def schema_names
-          select_value(<<-SQL, 'SCHEMA')
+          select_values(<<-SQL, 'SCHEMA')
             SELECT nspname
               FROM pg_namespace
              WHERE nspname !~ '^pg_.*'

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Redshift
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < ActiveRecord::ConnectionAdapters::SchemaCreation
         private
 
         def visit_ColumnDefinition(o)

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -158,8 +158,8 @@ module ActiveRecord
       def initialize(connection, logger, connection_parameters, config)
         super(connection, logger, config)
 
-        @visitor = Arel::Visitors::PostgreSQL.new self
-        @visitor.extend(ConnectionAdapters::DetermineIfPreparableVisitor)
+        # @visitor = Arel::Visitors::PostgreSQL.new self
+        # @visitor.extend(ConnectionAdapters::DetermineIfPreparableVisitor)
         @prepared_statements = false
 
         @connection_parameters = connection_parameters


### PR DESCRIPTION
schema_names is currently returning only 1 schema name.  Update code to use select_values so all schema names are returned.