### PR TITLE
Add optional keyword arguments

### DIFF
--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     class RedshiftColumn < Column #:nodoc:
       delegate :oid, :fmod, to: :sql_type_metadata
 
-      def initialize(name, default, sql_type_metadata, null = true, default_function = nil)
+      def initialize(name, default, sql_type_metadata, null = true, default_function = nil, **)
         super name, default, sql_type_metadata, null, default_function
       end
     end


### PR DESCRIPTION
In Rails 6.1, `Column.new` is assumed to receive an optional keyword argument. 

See https://github.com/rails/rails/commit/91712c5080cce23457f1f0e1e6dc7635f869b515#diff-38b55a4f9c4fea6b4bcc55597c963ad594c893f7957c09f4ae9177239e3f1ca5.