### PR TITLE
Add RedshiftColumn#array?

### DIFF
--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -3,6 +3,10 @@ module ActiveRecord
     class RedshiftColumn < Column #:nodoc:
       delegate :oid, :fmod, to: :sql_type_metadata
 
+      # Required for Rails 6.1, see https://github.com/rails/rails/pull/41756
+      mattr_reader :array, default: false
+      alias :array? :array
+
       def initialize(name, default, sql_type_metadata, null = true, default_function = nil)
         super name, default, sql_type_metadata, null, default_function
       end


### PR DESCRIPTION
Rails 6.1 requires that adapters define `Column#array?`, if they also define `Column#oid`.

Seems like a Rails bug to me. Reported here: https://github.com/rails/rails/pull/41756. But there is an easy workaround.