### PR TITLE
DetermineIfPreparableVisitor removed in Rails 6.1

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -159,7 +159,7 @@ module ActiveRecord
         super(connection, logger, config)
 
         @visitor = Arel::Visitors::PostgreSQL.new self
-        @visitor.extend(ConnectionAdapters::DetermineIfPreparableVisitor)
+        @visitor.extend(ConnectionAdapters::DetermineIfPreparableVisitor) if defined?(ConnectionAdapters::DetermineIfPreparableVisitor)
         @prepared_statements = false
 
         @connection_parameters = connection_parameters


### PR DESCRIPTION
ActiveRecord::ConnectionAdapters::DetermineIfPreparableVisitor has been removed in Rails 6.1.

See https://github.com/rails/rails/commit/72005ad0e13cb83d0e5ed7f9af7e0537efcf8963.

I am not 100 % sure that my fix for this handles this properly, but it works for me 🤷‍♂️