### PR TITLE
fix(variables): ensure we actually set variables we parse in connection config + minor Rails 6.1 fixes

### DIFF
--- a/lib/active_record/connection_adapters/redshift/column.rb
+++ b/lib/active_record/connection_adapters/redshift/column.rb
@@ -6,6 +6,12 @@ module ActiveRecord
       def initialize(name, default, sql_type_metadata, null = true, default_function = nil)
         super name, default, sql_type_metadata, null, default_function
       end
+
+      def array
+        false
+      end
+      alias :array? :array
+ 
     end
   end
 end

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Redshift
-      class SchemaCreation < AbstractAdapter::SchemaCreation
+      class SchemaCreation < ActiveRecord::ConnectionAdapters::SchemaCreation
         private
 
         def visit_ColumnDefinition(o)

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -159,7 +159,6 @@ module ActiveRecord
         super(connection, logger, config)
 
         @visitor = Arel::Visitors::PostgreSQL.new self
-        @visitor.extend(ConnectionAdapters::DetermineIfPreparableVisitor)
         @prepared_statements = false
 
         @connection_parameters = connection_parameters


### PR DESCRIPTION
I found a use case where I wanted to set something on the connection `wlm_query_slot_count` specifically, and realized that we were failing to apply variables like is done in the [Postgres adapater](https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L764-L799). It should be noted that `intervalstyle` is not supported, nor is the `SESSION` keyword on `SET`, so those have been dropped. 

Default timezone is `UTC` so actually applying that logic should not have any adverse impact unless someone had set that value and failed to notice it wasn't working.

I've also bundled a couple of fixes to `SchemaCreation` [inheritance](https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/connection_adapters/postgresql/schema_creation.rb) and `array` type availability (not available in Redshift), but otherwise no other general Rails 6.1 fixes. We've been running with these latter fixes in prod for a bit now.