### PR TITLE
fix(variables): ensure we actually set variables we parse in connection config

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -583,6 +583,17 @@ module ActiveRecord
             end
           end
 
+          # SET statements from :variables config hash
+          # https://www.postgresql.org/docs/current/static/sql-set.html
+          variables.map do |k, v|
+            if v == ":default" || v == :default
+              # Sets the value to the global or compile default
+              execute("SET #{k} TO DEFAULT", "SCHEMA")
+            elsif !v.nil?
+              execute("SET #{k} TO #{quote(v)}", "SCHEMA")
+            end
+          end
+
         end
 
         def last_insert_id_result(sequence_name) #:nodoc:


### PR DESCRIPTION
I found a use case where I wanted to set something on the connection (`wlm_query_slot_count` specifically), and realized that we were failing to apply variables like is done in the [Postgres adapter](https://github.com/rails/rails/blob/6-1-stable/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L764-L799). It should be noted that `intervalstyle` is not supported, nor is the `SESSION` keyword on `SET`, so those have been dropped. 

Default timezone is `UTC` so actually applying that logic should not have any adverse impact unless someone had set that value and failed to notice it wasn't working.