### PR TITLE
Use kwargs instead of hash for options argument

### DIFF
--- a/lib/active_record/connection_adapters/redshift/oid/decimal.rb
+++ b/lib/active_record/connection_adapters/redshift/oid/decimal.rb
@@ -3,7 +3,7 @@ module ActiveRecord
     module Redshift
       module OID # :nodoc:
         class Decimal < Type::Decimal # :nodoc:
-          def infinity(options = {})
+          def infinity(**options)
             BigDecimal.new("Infinity") * (options[:negative] ? -1 : 1)
           end
         end

--- a/lib/active_record/connection_adapters/redshift/schema_definitions.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_definitions.rb
@@ -30,18 +30,18 @@ module ActiveRecord
         # require you to assure that you always provide a UUID value before saving
         # a record (as primary keys cannot be +nil+). This might be done via the
         # +SecureRandom.uuid+ method and a +before_save+ callback, for instance.
-        def primary_key(name, type = :primary_key, options = {})
+        def primary_key(name, type = :primary_key, **options)
           return super unless type == :uuid
           options[:default] = options.fetch(:default, 'uuid_generate_v4()')
           options[:primary_key] = true
           column name, type, options
         end
 
-        def json(name, options = {})
+        def json(name, **options)
           column(name, :json, options)
         end
 
-        def jsonb(name, options = {})
+        def jsonb(name, **options)
           column(name, :jsonb, options)
         end
       end

--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -43,7 +43,7 @@ module ActiveRecord
       module SchemaStatements
         # Drops the database specified on the +name+ attribute
         # and creates it again using the provided +options+.
-        def recreate_database(name, options = {}) #:nodoc:
+        def recreate_database(name, **options) #:nodoc:
           drop_database(name)
           create_database(name, options)
         end
@@ -56,7 +56,7 @@ module ActiveRecord
         # Example:
         #   create_database config[:database], config
         #   create_database 'foo_development', encoding: 'unicode'
-        def create_database(name, options = {})
+        def create_database(name, **options)
           options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
           option_string = options.inject("") do |memo, (key, value)|
@@ -151,7 +151,7 @@ module ActiveRecord
           SQL
         end
 
-        def drop_table(table_name, options = {})
+        def drop_table(table_name, **options)
           execute "DROP TABLE #{quote_table_name(table_name)}#{' CASCADE' if options[:force] == :cascade}"
         end
 
@@ -221,7 +221,7 @@ module ActiveRecord
         end
 
         # Drops the schema for the given schema name.
-        def drop_schema(schema_name, options = {})
+        def drop_schema(schema_name, **options)
           execute "DROP SCHEMA#{' IF EXISTS' if options[:if_exists]} #{quote_schema_name(schema_name)} CASCADE"
         end
 
@@ -289,13 +289,13 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME TO #{quote_table_name(new_name)}"
         end
 
-        def add_column(table_name, column_name, type, options = {}) #:nodoc:
+        def add_column(table_name, column_name, type, **options) #:nodoc:
           clear_cache!
           super
         end
 
         # Changes the column of a table.
-        def change_column(table_name, column_name, type, options = {})
+        def change_column(table_name, column_name, type, **options)
           clear_cache!
           quoted_table_name = quote_table_name(table_name)
           sql_type = type_to_sql(type, limit: options[:limit], precision: options[:precision], scale: options[:scale])
@@ -342,7 +342,7 @@ module ActiveRecord
           execute "ALTER TABLE #{quote_table_name(table_name)} RENAME COLUMN #{quote_column_name(column_name)} TO #{quote_column_name(new_column_name)}"
         end
 
-        def add_index(table_name, column_name, options = {}) #:nodoc:
+        def add_index(table_name, column_name, **options) #:nodoc:
         end
 
         def remove_index!(table_name, index_name) #:nodoc:

--- a/test/active_record/connection_adapters/fake_adapter.rb
+++ b/test/active_record/connection_adapters/fake_adapter.rb
@@ -25,7 +25,7 @@ module ActiveRecord
         @primary_keys[table]
       end
 
-      def merge_column(table_name, name, sql_type = nil, options = {})
+      def merge_column(table_name, name, sql_type = nil, **options)
         @columns[table_name] << ActiveRecord::ConnectionAdapters::Column.new(
           name.to_s,
           options[:default],

--- a/test/cases/adapters/sqlite3/copy_table_test.rb
+++ b/test/cases/adapters/sqlite3/copy_table_test.rb
@@ -10,7 +10,7 @@ class CopyTableTest < ActiveRecord::TestCase
     end
   end
 
-  def test_copy_table(from = 'customers', to = 'customers2', options = {})
+  def test_copy_table(from = 'customers', to = 'customers2', **options)
     assert_nothing_raised {copy_table(from, to, options)}
     assert_equal row_count(from), row_count(to)
 
@@ -77,7 +77,7 @@ class CopyTableTest < ActiveRecord::TestCase
   end
 
 protected
-  def copy_table(from, to, options = {})
+  def copy_table(from, to, **options)
     @connection.copy_table(from, to, {:temporary => true}.merge(options))
   end
 

--- a/test/cases/test_case.rb
+++ b/test/cases/test_case.rb
@@ -31,7 +31,7 @@ module ActiveRecord
       assert failed_patterns.empty?, "Query pattern(s) #{failed_patterns.map{ |p| p.inspect }.join(', ')} not found.#{SQLCounter.log.size == 0 ? '' : "\nQueries:\n#{SQLCounter.log.join("\n")}"}"
     end
 
-    def assert_queries(num = 1, options = {})
+    def assert_queries(num = 1, **options)
       ignore_none = options.fetch(:ignore_none) { num == :any }
       SQLCounter.clear_log
       x = yield
@@ -45,7 +45,7 @@ module ActiveRecord
       x
     end
 
-    def assert_no_queries(options = {}, &block)
+    def assert_no_queries(**options, &block)
       options.reverse_merge! ignore_none: true
       assert_queries(0, options, &block)
     end

--- a/test/models/contact.rb
+++ b/test/models/contact.rb
@@ -23,7 +23,7 @@ module ContactFakeColumns
   end
 
   # mock out self.columns so no pesky db is needed for these tests
-  def column(name, sql_type = nil, options = {})
+  def column(name, sql_type = nil, **options)
     connection.merge_column(table_name, name, sql_type, options)
   end
 end


### PR DESCRIPTION
The `options` hash argument has been deprecated since Ruby 2.7, and replaced by keyword arguments in Rails code for roughly 3 years (see commit https://github.com/rails/rails/commit/b57ca840a6fe64b7a76bc6585dff26e5c08879fb, for example).

After upgrading from Ruby 2.7 to 3.1, our migrations stopped working entirely, because Ruby 3.1 (or maybe 3.0 too) won't allow you calling a `super` with kwargs from a method with a hash argument.

The solution is to match Rails code and use kwargs.